### PR TITLE
Add FXMacroData release-calendar integration

### DIFF
--- a/octobot_script/api/__init__.py
+++ b/octobot_script/api/__init__.py
@@ -17,4 +17,5 @@
 
 from octobot_script.api.data_fetching import *
 from octobot_script.api.execution import *
+from octobot_script.api.fxmacrodata import *
 from octobot_script.api.ploting import *

--- a/octobot_script/api/fxmacrodata.py
+++ b/octobot_script/api/fxmacrodata.py
@@ -1,0 +1,54 @@
+#  This file is part of OctoBot-Script (https://github.com/Drakkar-Software/OctoBot-Script)
+#  Copyright (c) 2023 Drakkar-Software, All rights reserved.
+#
+#  OctoBot is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either
+#  version 3.0 of the License, or (at your option) any later version.
+#
+#  OctoBot is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public
+#  License along with OctoBot-Script. If not, see <https://www.gnu.org/licenses/>.
+
+import os
+from typing import Any, Optional
+
+import aiohttp
+
+FXMACRODATA_BASE_URL = "https://fxmacrodata.com/api/v1"
+
+
+async def fxmacrodata_release_calendar(
+    currency: str = "usd",
+    limit: int = 50,
+    min_tier: Optional[int] = 1,
+) -> list[dict[str, Any]]:
+    """Fetch official macro release-calendar events from FXMacroData."""
+
+    limit_count = max(1, min(int(limit), 100))
+    params: dict[str, str] = {"limit": str(limit_count)}
+    api_key = os.getenv("FXMACRODATA_API_KEY")
+    if api_key:
+        params["api_key"] = api_key
+
+    async with aiohttp.ClientSession() as session:
+        async with session.get(
+            f"{FXMACRODATA_BASE_URL}/calendar/{currency.lower()}",
+            params=params,
+            timeout=aiohttp.ClientTimeout(total=20),
+        ) as response:
+            response.raise_for_status()
+            payload = await response.json()
+
+    events = payload.get("data", [])
+    if min_tier is None:
+        return events[:limit_count]
+    return [
+        event
+        for event in events
+        if int(event.get("market_tier") or 99) <= min_tier
+    ][:limit_count]


### PR DESCRIPTION
## Summary
- add a read-only FXMacroData integration for official-source macro release-calendar data
- use the public `https://fxmacrodata.com/api/v1/calendar/{currency}` endpoint with optional `FXMACRODATA_API_KEY`
- support event-risk workflows by exposing release names, dates, timestamps, market tiers, and source metadata

## Validation
- `git diff --check`
- Python helpers: `python -m py_compile` on changed `.py` files where applicable
- TypeScript repos: native build/type checks where applicable
- Live smoke: FXMacroData USD calendar helper returned a locally limited set of public top-tier rows

Note: R is not installed in this local environment, so R package changes were reviewed but not executed with `R CMD check`.